### PR TITLE
SymPy CZI Wrapup Blog Post

### DIFF
--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -47,15 +47,14 @@ three work packages led by each of the three co-principal investigators:
 
 We were in charge of the last work package and hired Dr. Sam Brockie to work on
 the project as a postdoctoral researcher. Jan Heinen and Timo Stienstra worked
-on the project through their TU Delft MSc projects under the supervision of Sam
+on the project through their TU Delft MSc degrees under the supervision of Sam
 and Jason.
 
 Our overarching goal is to use SymPy to generate symbolic dynamical models of
 biomechanical systems, i.e. multibody systems actuated by muscles. This
 involves formulating the Newton-Euler equations of motion, possibly with
-additional kinematical constraints, and the differential equations that
-describe the relationship between neurological excitation and generated muscles
-forces.
+additional kinematic constraints, and the differential equations that describe
+the relationship between neurological excitation and generated muscles forces.
 
 We selected a complex human-machine system as a benchmark problem to motivate
 our work: the bicycle and its rider. The nonlinear and linear equations of
@@ -67,13 +66,15 @@ is made up of millions of arithmetic and transcendental operations, making it a
 challenging system to differentiate and evaluate efficiently. We want SymPy to
 be able to handle models of this complexity with ease. To test SymPy's ability
 to correctly derive, differentiate, and evaluate the bicycle-rider's governing
-equations, we choose to formulate and solve an optimal control problem via
-direct collocation. We knew that the bicycle-rider optimal control problem
-would test SymPy's limits, forcing us to make significant improvements to
-SymPy's code generation features. To do this, we worked on numerous areas in
-SymPy and downstream packages to reach this goal.
+equations, we choose to formulate and solve a `trajectory optimization`_
+problem via `direct collocation`_. We knew that this bicycle-rider optimal
+control problem would test SymPy's limits, forcing us to make significant
+improvements to SymPy's code generation features. To do this, we worked on
+numerous areas in SymPy and downstream packages to reach this goal.
 
 .. _SymPy: https://www.sympy.org
+.. _trajectory optimization: https://en.wikipedia.org/wiki/Trajectory_optimization
+.. _direct collocation: https://en.wikipedia.org/wiki/Collocation_method
 
 General Improvements to SymPy Mechanics
 =======================================
@@ -82,7 +83,7 @@ Joints Package
 --------------
 
 Timo Stienstra began working on this project through a 2022 Google Summer of
-Code internship where he improved the SymPy Mechanics joints modules with
+Code internship where he improved the SymPy Mechanics `joints modules`_ with
 documentation improvements, by reworking the fundamental definition of a joint,
 and adding new cylindrical, planar, and spherical joints. These were key early
 updates to enable the joints package's use in constructing a bicycle-rider
@@ -91,6 +92,8 @@ Timo to do a TU Delft Biomechanical Design MSc project on bicycle-rider
 modeling using SymPy.
 
 .. _GSoC Report: https://github.com/sympy/sympy/wiki/GSoC-2022-Report-Timo-Stienstra-:-Enhancing-the-Joints-Framework
+
+.. _joints modules: https://docs.sympy.org/latest/modules/physics/mechanics/joints.html
 
 .. list-table:: Figure 1: Old and new joint types with new explanatory figures
    can be found in the SymPy documentation.
@@ -297,12 +300,10 @@ Inertia, Loads, Actuators
 
 We introduced three new helper classes to extend the functionality of inertia
 and loads beyond that of simply dyadics and vectors: ``Inertia()``,
-``Force()``, and ``Torque()``.
-
-The inertia object lets you associate a dyadic with a point, to completely
-define inertia for a rigid body, particle, or collection of them. Force and
-Torque are named tuples that associate a vector and point and a vector and a
-frame, respectively.
+``Force()``, and ``Torque()``. The inertia object lets you associate a dyadic
+with a point, to completely define inertia for a rigid body, particle, or
+collection of them. Force and Torque are named tuples that associate a vector
+and point and a vector and a frame, respectively.
 
 We have introduced an actuator_ module that has classes that describe the
 equal and opposite pair of forces or torques and force actuators can operate
@@ -333,10 +334,10 @@ works.
 Introducing SymPy Biomechanics
 ==============================
 
-We have developed a new sub-package, sympy.physics.biomechanics_, that enables
-including musculotendon force actuators in multibody dynamics models created
-with ``sympy.physics.mechanics``. ``biomechanics`` contains these primary
-modules:
+We have developed a substantial new sub-package, sympy.physics.biomechanics_,
+that enables including musculotendon force actuators in multibody dynamics
+models created with ``sympy.physics.mechanics``. ``biomechanics`` contains
+these primary modules:
 
 - ``curve.py``: contains classes that represent mathematical functional
   relationships between the time-varying muscle-tendon length, velocity, and
@@ -478,14 +479,14 @@ Modeling and Optimal Control Uses
 As explained in the introduction, our goal is to make SymPy capable of deriving
 computationally efficient neuromuscular driven multibody models. One use case
 for these models is solving `optimal control`_ problems, which benefit greatly
-from the fastest numerical evaluation of the equations of motion and its
-higher-order partial derivatives. In particular, forming a `nonlinear
-programming`_ problem using direct collocation transcription from very large
-symbolic equations of motion was already known to push SymPy's past its limits.
-In the past, we have developed two software packages that transcribe and solve
-optimal control problems based on SymPy expressions: opty_ and pycollo_. We use
-both programs below to solve two challenging optimal control problems and
-detail the improvements we made to the packages.
+from exact derivatives and the fastest numerical evaluation of the equations of
+motion and its higher-order partial derivatives. In particular, forming a
+`nonlinear programming`_ problem using direct collocation transcription from
+very large symbolic equations of motion was already known to push SymPy's past
+its limits.  In the past, we have developed two software packages that
+transcribe and solve optimal control problems based on SymPy expressions: opty_
+and pycollo_. We use both programs below to solve two challenging optimal
+control problems and detail the improvements we made to the packages.
 
 .. _optimal control: https://en.wikipedia.org/wiki/Optimal_control
 .. _nonlinear programming: https://en.wikipedia.org/wiki/Nonlinear_programming
@@ -592,7 +593,7 @@ attempted the differentiation for the Jacobian of the discretized bicycle-rider
 model, SymPy bogged down on the Jacobian calculation. We let the computation
 run for **over 3 hours** and killed the execution before the computation
 completed. SymPy's differentiation is unusable for interactive work with large
-equations of motion, such as these. Since we already find the common
+equations of motion such as these. Since we already find the common
 sub-expressions of the equations of motion before code generation in opty, Sam
 implemented a very efficient forward Jacobian on the expression directed
 acyclic graph (DAG) in pull request: https://github.com/csu-hmc/opty/pull/102.
@@ -655,17 +656,18 @@ https://github.com/brocksam/muscle-driven-bicycle-paper
 
 The need to evaluate both a function and its Jacobian is a common use case that
 is not just limited to optimal control problems like the one shown above. SymPy
-is capable of taking the analytical derivatives but it can be prohibitory slow
-for large expressions. This limits interactive use and rapid iteration in
-equation derivation. If common sub-expressions are extracted from a SymPy
-expression, all operations are represented as a directed acyclic graph.  Taking
-the derivative of a DAG instead of a tree graph, as SymPy stores expressions,
-can provide exponential speedups to differentiation. If the code generation for
-the function and its Jacobian uses common sub-expression elimination, then it
-makes sense to call ``cse()`` on the function, then take the partial
-derivatives, and the Jacobian will be in a DAG form for easy code generation.
-Sam has introduced a major code generation speed up for lambdifying large SymPy
-expressions if you also desire the Jacobian in the following pull requests:
+is capable of taking analytical derivatives but it can be prohibitory slow for
+large expressions. This limits interactive use and rapid iteration in equation
+derivation. If common sub-expressions are extracted from a SymPy expression,
+all operations are represented as a directed acyclic graph.  Taking the
+derivative of a DAG instead of a tree graph, as SymPy stores expressions, can
+provide exponential speedups to differentiation. If the code generation for the
+function and its Jacobian uses common sub-expression elimination, then it makes
+sense to call ``cse()`` on the function, then take the partial derivatives, and
+the Jacobian will be in a DAG form for easy code generation. Sam has
+introduced a major code generation speed up for lambdifying large SymPy
+expressions if you also desire the Jacobian based on the work we did in opty.
+The details are  in the following pull requests:
 
 - https://github.com/sympy/sympy/pull/24649
 - https://github.com/sympy/sympy/pull/25797
@@ -694,10 +696,10 @@ pull requests because he built out the tests with advanced pytest features.
 
 We had planned for 0.5 FTE over the two year period, but it took about 6 months
 to negotiate a subcontract between TU Delft and Quantsight, since it was the
-first one of its kind. After that, it took another six months before Sam could
-start. There was not enough time in the grant period for the contract and
-hiring process. It still worked out, but this is something to plan for in the
-future.
+first one of its kind. After that, it took another six months before we
+interivewed candidates, hired one, and Sam could start. There was not enough
+time in the grant period for the contract and hiring process. It still worked
+out, but this is something to plan for in the future.
 
 We developed a large plan for the additions to SymPy that was tough to separate
 into independent smaller pieces. This led Sam and Timo to work on a set of
@@ -721,8 +723,8 @@ collaboration.
 Work Summary
 ============
 
-The following list summarizes the various products we have (so far) delivered
-as part of the CZI funding (code, papers, documentation):
+The following list summarizes the various products we have delivered as part of
+the CZI funding (code, papers, documentation):
 
 - Pull requests to SymPy:
 

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -9,6 +9,9 @@ SymPy CZI Code Generation & Biomechanics Outcomes
 :authors: Jason K. Moore, Sam Brockie
 :summary: TODO
 
+Introduction
+============
+
 We were awarded a two year grant from CZI to improve SymPy_. There were three
 themes associated with each of the three co-principal investigators:
 
@@ -240,6 +243,7 @@ tutorial.
 
 .. figure:: https://docs.sympy.org/dev/_images/biomechanics-steerer.svg
    :align: center
+   :width: 80%
 
    Muscle driven arm pushing and pulling a lever taken from the new tutorial.
 
@@ -252,9 +256,11 @@ lambdify should handle large expressions (didn't handle bike model before,
 point to pydy PR)
 
 - code gen
+
   - lambdify docstring speed up
   - MatrixSolve
   - cse jacobian
+
 - dagify
 - cse jacobian
 
@@ -279,19 +285,20 @@ problems based on SymPy expressions: opty_ and pycollo_.
 Optimal Skateboard Ollie
 -------------------------
 
-As a first demonstration that SymPy can be used to help solve complex optimal
-control problems, TU Delft MSc student Jan Heinen began working on developing a
-model of a skateboarder performing an ollie, the fundamental jumping trick in
-the sport. Jan used SymPy to formulate the equations of motion of this
-biomechanical human-machine system and used pycollo to solve the multi-phase
-trajectory optimization and parameter identification optimal control problem.
-Jan succeeded and produced an MSc thesis and a preprint that is currently udner
-review at Sports Engineering:
+As a first demonstration that SymPy can be used to solve research grade complex
+optimal control problems, TU Delft MSc student Jan Heinen began working on
+developing a model of a skateboarder performing an ollie, the fundamental
+jumping trick in the sport. Jan used SymPy to formulate the equations of motion
+of this biomechanical human-machine system and used pycollo to solve the
+multi-phase trajectory optimization and parameter identification optimal
+control problem.  Jan succeeded and produced an MSc thesis and a preprint that
+is currently udner review at Sports Engineering:
 
-- `Optimal Skateboard Geometry for Maximizing Ollie Height
-  <http://resolver.tudelft.nl/uuid:61f4e969-8bd1-4687-9942-b70024b216dc>`_"
-- `Maximizing Ollie Height by Optimizing Control Strategy and Skateboard
-  Geometry Using Direct Collocation <https://doi.org/10.31224/3171>`_
+- TU Delft MSc thesis: `Optimal Skateboard Geometry for Maximizing Ollie Height
+  <http://resolver.tudelft.nl/uuid:61f4e969-8bd1-4687-9942-b70024b216dc>`_
+- engrXiv preprint: `Maximizing Ollie Height by Optimizing Control Strategy and
+  Skateboard Geometry Using Direct Collocation
+  <https://doi.org/10.31224/3171>`_
 
 This video shows the simulations of the problem solutions:
 
@@ -317,9 +324,29 @@ project with the following pull requests:
 BRiM
 ----
 
-- BMD paper & Timo's thesis
+All of our prior bicycle-rider human-machine system models were one-off
+derivations that were repurposed for each new model variation. These had
+varying accessiblity for easy use by other users. Timo came up with the idea to
+develop a software package that allows you to build bicycle-rider models from
+modular elements, yet still retain a minimial coorindate derivation of the
+equations of motion. His MSc thesis, "`BRiM: A Modular Bicycle-Rider Modeling
+Framework
+<http://resolver.tudelft.nl/uuid:a2b132e9-8d38-4553-8587-0c9e3341b202>`__",
+details the design, implementation, and use of BRiM. We also wrote a paper,
+"`BRiM: A Modular Bicycle-Rider Modeling Framework
+<https://doi.org/10.59490/6504c5a765e8118fc7b106c3>`__", for the Bicycle and
+Motorcycle Dynamics 2023 conference that gives a more concise overview of the
+package as well as demonstrating easily swapping models for optimal control
+results.
 
-  doi.org/10.59490/6504c5a765e8118fc7b106c3
+.. figure:: https://tjstienstra.github.io/brim/_images/lane_change.gif
+   :align: center
+   :width: 80%
+
+   Lane change simulation created with BRiM showing without and without a rider
+
+- BRiM source code: https://github.com/TJStienstra/brim/
+- BRiM documentation: https://tjstienstra.github.io/brim/
 
 Optimal Bicycle-Rider Trajectories
 ----------------------------------

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -2,9 +2,10 @@
 SymPy CZI Code Generation & Biomechanics Outcomes
 =================================================
 
-:date: 2023-09-28 00:00:00
-:tags: sympy, czi, biomechanics
-:category: news
+:date: 2023-10-26 00:00:00
+:tags: sympy, czi, biomechanics, multibody dynamics, open source software,
+       muscles, optimal control, bicycle, skateboard, code generation
+:category: research
 :slug: sympy-czi-outcomes
 :authors: Jason K. Moore, Sam Brockie
 :summary: Summary of the work performed under the Chan-Zuckerberg Foundation

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -56,9 +56,9 @@ We selected a complex human-machine system as a benchmark problem to motivate
 our work: the bicycle and its rider. The nonlinear and linear equations of
 motion of a riderless bicycle have traditionally been a very challenging system
 to derive correctly in full symbolic form (see [BasuMandal2007]_ and
-[Meijaard2007]_ for background). Including a model of a human rider with muscle
-driven joints increases the model's complexity even further. This model is made
-up of millions of arithmetic and transcendental operations, making it a
+[Meijaard2007]_ for background). Including a model of a human rider with
+muscle-driven joints increases the model's complexity even further. This model
+is made up of millions of arithmetic and transcendental operations, making it a
 challenging system to differentiate and evaluate efficiently. We want SymPy to
 be able to handle models of this complexity with ease. To test SymPy's ability
 to correctly derive, differentiate, and evaluate the bicycle-rider's governing
@@ -77,7 +77,7 @@ Joints Package
 --------------
 
 Timo Stienstra began working on this project through a 2022 Google Summer of
-Code internship where he improved the SymPy Mechanics Joints package with
+Code internship where he improved the SymPy Mechanics joints modules with
 documentation improvements, by reworking the fundamental definition of a joint,
 and adding new cylindrical, planar, and spherical joints. These were key early
 updates to enable the joints package's use in constructing a bicycle-rider
@@ -444,14 +444,14 @@ Modeling and Optimal Control Uses
 As explained in the introduction, our goal is to make SymPy capable of deriving
 computationally efficient neuromuscular driven multibody models. One use case
 for these models is solving `optimal control`_ problems, which benefit greatly
-from the fastest numerical evaluation of the equations of motion and its higher
-order partial derivatives. In particular, forming a `nonlinear programming`_
-problem using direct collocation transcription from very large symbolic
-equations of motion was already known to push SymPy's past its limits. In the
-past, we have developed two software packages that transcribe and solve optimal
-control problems based on SymPy expressions: opty_ and pycollo_. We use both
-programs below to solve two challenging optimal control problems and detail the
-improvements we made to the packages.
+from the fastest numerical evaluation of the equations of motion and its
+higher-order partial derivatives. In particular, forming a `nonlinear
+programming`_ problem using direct collocation transcription from very large
+symbolic equations of motion was already known to push SymPy's past its limits.
+In the past, we have developed two software packages that transcribe and solve
+optimal control problems based on SymPy expressions: opty_ and pycollo_. We use
+both programs below to solve two challenging optimal control problems and
+detail the improvements we made to the packages.
 
 .. _optimal control: https://en.wikipedia.org/wiki/Optimal_control
 .. _nonlinear programming: https://en.wikipedia.org/wiki/Nonlinear_programming

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -1,0 +1,139 @@
+=================================================
+SymPy CZI Code Generation & Biomechanics Outcomes
+=================================================
+
+:date: 2023-09-28 00:00:00
+:tags: sympy, czi, biomechanics
+:category: news
+:slug: sympy-czi-outcomes
+:authors: Jason K. Moore, Sam Brockie
+:summary: TODO
+
+We were awarded a two year grant from CZI to improve SymPy. There were three
+themes associated with each of the three co-principal investigators:
+
+- Improve SymPy's documentation (Meuer)
+- Improve SymPy's Performance (Benjamin)
+- Improve SymPy's Code Generation to Support Biomechanical Modeling (Moore)
+
+We were in charge of the last one.
+
+An overarching goal is to make SymPy usuable to generate symbolic models of
+biomechanical systems, i.e. multibody systems actuated by muscles. Our target
+system is the bicycle and its rider. The nonlinear and linear equations of
+motion of a bicycle are traditionally a challenging system to derive correctly
+full symbolic form. Including a model of a human rider increases its complexity
+further. This model is made up of many thousands of arthemtic and transcendtal
+operations, making it a challenging system to differentiate and evaluate. We
+want SymPy to be able to handle models of this and more complexity with ease.
+Formulating and solving optimal control problems with the bicyle-rider system
+currently tests the limits of SymPy's abilities.
+
+We worked on numerous areas in SymPy and downstream packages to reach the goal
+of solving a bicycle-rider biomechanical optimal control problem.
+
+General Improvements to SymPy Mechanics
+=======================================
+
+Symbolic Solutions to Linear Equations
+--------------------------------------
+
+Kane's Method relies on solving three sets of linear equations:
+
+1. putting the kinematical differential equations in explicit form
+2. putting the dynamical differential equations in explicit form
+3. solving the dependent generalized speeds in terms of the indepdent
+  generalised speeds
+
+If these equations are symbolic, it is impossible to determine a zero-pivot in
+Gaussian elimination and the solutions can easily aquire divide-by-zero
+operattions for ranges of numerical values for the variables involved.
+
+There are two ways to deal with this 1) only do these solves numerically and 2)
+ensure there are no zero-divisions with careful choice of algorthm or variable
+choice. 1. is easy to manage if you set q' = u.
+
+In ?2014?, we switched to using ``LUsolve()`` for all of these linear solves,
+which resulted in divide-by-zero issues for complex problems. We introduced a
+new solver that uses Cramer's method, which can eliinate divide-by-zero
+operations in many situations. ``KanesMethod`` and ``Linearizer`` now support
+selecting the linear solver, including the new Cramer solver. This allowed us
+to fix a test that had been failing for almost 10 years.
+
+.. code-block:: python
+
+   A = MatrixSymbol('A', 4, 4)
+   b = MatrixSymbol('b', 4, 2)
+   x = Inverse(A) @ b
+   result = x[0, 0] + x[1, 0] + x[2, 0] + x[3, 0]
+   eval_x = lambdify((A, b), result)
+
+We'd like lambdify to generate code that looks like:
+
+.. code-block:: python
+
+   def eval_x(A, b):
+      x = numpy.linalg.solve(A, b)
+      return x[0, 0] + x[1, 0] + x[2, 0] + x[3, 0]
+
+which allows NumPy (or actually lapack) to use the best algorithm given the
+numerical values used for A and b. The expression `Inverse(A) @ b` would need
+to remain unevaluated for that to work.
+
+Inertia, Loads, Actuators
+-------------------------
+
+We introduced three helper classes:
+
+- ``Inertia()``
+- ``Force``, ``Torque``
+
+The inertia object lets you associate a dyadic with a point, to completely
+define an inertia. Force and Torque are named tuples that associate a vector
+and point and a vector and a frame, respectively.
+
+An Actuator describes the equal and opposite pair of forces or torques.
+
+System
+------
+
+Introduction of SymPy Biomechanics
+==================================
+
+SymPy Code Generation
+=====================
+
+lambdify should handle large expressions
+
+- code gen
+  - lambdify docstring speed up
+  - MatrixSolve
+- dagify
+
+BRiM
+====
+
+- BMD paper & Timo's thesis
+
+Optimal Skateboard Ollie
+========================
+
+- Jan's work: thesis & paper
+- pycollo documentation
+
+Optimal Bicycle-Rider Trajectories
+==================================
+
+- opty improvements
+- muscle driven bicycle model
+
+Lessons Learned
+===============
+
+- 6 months to negotiate a contract
+- 6 months to hire someone
+
+People
+======
+
+Timo, Sam, Jan, Jason

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -720,6 +720,19 @@ collaborative work between the two related work packages. In the future, it
 would be good to have more early brainstorm meetings to initiate close
 collaboration.
 
+Future Plans
+------------
+
+We plan to finish any of the unmerged pull requests for the SymPy 1.13 release
+and the paper on the optimal control of the bicycle-rider system is ongoing
+work. In the future, we are very interested in incorporating unevaluated
+expressions and the DAG data structures more into the core of SymPy, as these
+two ideas can vastly enhance SymPy's performance and the ability to code
+generate from SymPy expressions with more control and precision. We hope that
+other users will try out and contribute to the new biomechanics package as well
+as use SymPy + opty & pycollo for solving optimal control problems of
+biomechanical multibody systems.
+
 Work Summary
 ============
 

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -12,11 +12,15 @@ SymPy CZI Code Generation & Biomechanics Outcomes
 We were awarded a two year grant from CZI to improve SymPy_. There were three
 themes associated with each of the three co-principal investigators:
 
-- Improve SymPy's Documentation (Meuer)
-- Improve SymPy's Performance (Benjamin)
-- Improve SymPy's Code Generation for Biomechanical Modeling (Moore)
+- Improve SymPy's Documentation (Aaron Meuer, Quantsight)
+- Improve SymPy's Performance (Oscar Benjamin, University of Bristol)
+- Improve SymPy's Code Generation for Biomechanical Modeling (Jason K. Moore,
+  Delft University of Technology)
 
-We were in charge of the last one.
+We were in charge of the last one and hired Dr. Sam Brockie to work on the
+project as a postdoctoral researcher. Jan Heinen and Timo Stienstra worked on
+the project through their TU Delft MSc projects under the supervision of Sam
+and Jason.
 
 Our overarching goal is to use SymPy to generate symbolic dynamical models of
 biomechanical systems, i.e. multibody systems actuated by muscles. This
@@ -31,16 +35,14 @@ bicycle are traditionally a very challenging system to derive correctly in full
 symbolic form ( [BasuMandal2007]_, [Meijaard2007]_). Including a model of a
 human rider with muscle activation increases its complexity even further. This
 model is made up of hundreds of thousands of arithmetic and transcendental
-operations, making it a challenging system to differentiate and evaluate. We
-want SymPy to be able to handle models of this and more complexity with ease.
-To test SymPy's ability to correctly derive, differentiate, and evaluate the
-bicycle-rider's governing equations we choose to formulate and solve an optimal
-control problem via direct collocation. The bicycle-rider optimal control
-problem would test SymPy's limits.
-
-To do this, we worked on numerous areas in SymPy and downstream packages to
-reach this goal. The work herein was primarily done by Timo Steinstra, Jan
-Heinen, Sam Brockie, and Jason Moore.
+operations, making it a challenging system to differentiate and evaluate
+efficiently. We want SymPy to be able to handle models of this and more
+complexity with ease.  To test SymPy's ability to correctly derive,
+differentiate, and evaluate the bicycle-rider's governing equations we choose
+to formulate and solve an optimal control problem via direct collocation. We
+beleived that the bicycle-rider optimal control problem would test SymPy's
+limits, forcing us to make significant improvements to SymPy. To do this, we
+worked on numerous areas in SymPy and downstream packages to reach this goal.
 
 .. _SymPy: https://www.sympy.org
 
@@ -228,15 +230,16 @@ modules:
 - ``musculotendon.py``: contains classes that represent complete musculatendon
   models with one example implementation
 
-We have also developed two tutorials to introduce how to construct and use the
-new acutators:
-
-- `Introduction to Biomechanical Modeling
-  <https://docs.sympy.org/dev/tutorials/biomechanics/biomechanics.html>`_
-- `Biomechanical Model Example
-  <https://docs.sympy.org/dev/tutorials/biomechanics/biomechanical-model-example.html>`_
+A full explanation of this package and the modules can be found in the new
+`Introduction to Biomechanical Modeling
+<https://docs.sympy.org/dev/tutorials/biomechanics/biomechanics.html>`_
+tutorial. We demonstrate the package on a non-trivial system in the new
+`Biomechanical Model Example
+<https://docs.sympy.org/dev/tutorials/biomechanics/biomechanical-model-example.html>`_
+tutorial.
 
 .. figure:: https://docs.sympy.org/dev/_images/biomechanics-steerer.svg
+   :align: center
 
    Muscle driven arm pushing and pulling a lever taken from the new tutorial.
 
@@ -332,13 +335,13 @@ https://github.com/csu-hmc/opty/pull/102
 - opty improvements
 - muscle driven bicycle model
 
+Other
+=====
+
+pytest pr
+
 Lessons Learned
 ===============
 
 - 6 months to negotiate a contract
 - 6 months to hire someone
-
-People
-======
-
-Timo, Sam, Jan, Jason

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -1,6 +1,6 @@
-=================================================
-SymPy CZI Code Generation & Biomechanics Outcomes
-=================================================
+=======================================================
+SymPy CZI Grant Code Generation & Biomechanics Outcomes
+=======================================================
 
 :date: 2023-10-27 00:00:00
 :tags: sympy, czi, biomechanics, multibody dynamics, open source software,

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -17,8 +17,8 @@ SymPy CZI Code Generation & Biomechanics Outcomes
    * - |sympy-logo|
      - |czi-logo|
 
-.. |sympy-logo| image:: https://objects-us-east-1.dream.io/mechmotum/sympy-logo.png
-   :height: 160px
+.. |sympy-logo| image:: https://docs.sympy.org/dev/_images/sympy-500px.png
+   :height: 200px
 
 .. |czi-logo| image:: https://objects-us-east-1.dream.io/mechmotum/czi-logo.png
    :height: 200px

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -62,11 +62,31 @@ to fix a test that had been failing for almost 10 years.
 
 .. code-block:: python
 
-   A = MatrixSymbol('A', 4, 4)
-   b = MatrixSymbol('b', 4, 2)
+   A = MatrixSymbol('A', 2, 2)
+   b = MatrixSymbol('b', 2, 1)
    x = Inverse(A) @ b
-   result = x[0, 0] + x[1, 0] + x[2, 0] + x[3, 0]
+   result = x[0, 0] + x[1, 0]
    eval_x = lambdify((A, b), result)
+
+The above works but the linear solve is handled symbolically::
+
+   Signature: f(A, b)
+   Docstring:
+   Created with lambdify. Signature:
+
+   func(A, b)
+
+   Expression:
+
+   A[0, 0]*b[1, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) - A[0, 1]*b[1, 0]/(A[0,...
+
+   Source code:
+
+   def _lambdifygenerated(A, b):
+       return A[0, 0]*b[1, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) - A[0, 1]*b[1, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) - A[1, 0]*b[0, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) + A[1, 1]*b[0, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0])
+
+
+   Imported modules:
 
 We'd like lambdify to generate code that looks like:
 
@@ -74,7 +94,7 @@ We'd like lambdify to generate code that looks like:
 
    def eval_x(A, b):
       x = numpy.linalg.solve(A, b)
-      return x[0, 0] + x[1, 0] + x[2, 0] + x[3, 0]
+      return x[0, 0] + x[1, 0]
 
 which allows NumPy (or actually lapack) to use the best algorithm given the
 numerical values used for A and b. The expression `Inverse(A) @ b` would need

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -739,6 +739,10 @@ as part of the CZI funding (code, papers, documentation):
   - https://github.com/brocksam/pycollo/pull/87
   - https://github.com/brocksam/pycollo/pull/88
 
+- Ollie Optimization paper and code:
+
+  - https://github.com/mechmotum/ollie-optimization
+
 - BRiM software package:
 
   - Source code: https://github.com/TJStienstra/brim/

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -2,7 +2,7 @@
 SymPy CZI Code Generation & Biomechanics Outcomes
 =================================================
 
-:date: 2023-10-26 00:00:00
+:date: 2023-10-27 00:00:00
 :tags: sympy, czi, biomechanics, multibody dynamics, open source software,
        muscles, optimal control, bicycle, skateboard, code generation
 :category: research

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -9,31 +9,63 @@ SymPy CZI Code Generation & Biomechanics Outcomes
 :authors: Jason K. Moore, Sam Brockie
 :summary: TODO
 
-We were awarded a two year grant from CZI to improve SymPy. There were three
+We were awarded a two year grant from CZI to improve SymPy_. There were three
 themes associated with each of the three co-principal investigators:
 
-- Improve SymPy's documentation (Meuer)
+- Improve SymPy's Documentation (Meuer)
 - Improve SymPy's Performance (Benjamin)
-- Improve SymPy's Code Generation to Support Biomechanical Modeling (Moore)
+- Improve SymPy's Code Generation for Biomechanical Modeling (Moore)
 
 We were in charge of the last one.
 
-An overarching goal is to make SymPy usuable to generate symbolic models of
-biomechanical systems, i.e. multibody systems actuated by muscles. Our target
-system is the bicycle and its rider. The nonlinear and linear equations of
-motion of a bicycle are traditionally a challenging system to derive correctly
-full symbolic form. Including a model of a human rider increases its complexity
-further. This model is made up of many thousands of arthemtic and transcendtal
+Our overarching goal is to use SymPy to generate symbolic dynamical models of
+biomechanical systems, i.e. multibody systems actuated by muscles. This
+involves formulating the Newton-Euler equations of motion, possibly with
+additional kinematical constraints, and the differential equations that
+describe the relationship between neurological activation and generated muscles
+forces.
+
+We selected a complex human-machine system as a benchmark problem: the bicycle
+and its rider. The nonlinear and linear equations of motion of a riderless
+bicycle are traditionally a very challenging system to derive correctly in full
+symbolic form ( [BasuMandal2007]_, [Meijaard2007]_). Including a model of a
+human rider with muscle activation increases its complexity even further. This
+model is made up of hundreds of thousands of arithmetic and transcendental
 operations, making it a challenging system to differentiate and evaluate. We
 want SymPy to be able to handle models of this and more complexity with ease.
-Formulating and solving optimal control problems with the bicyle-rider system
-currently tests the limits of SymPy's abilities.
+To test SymPy's ability to correctly derive, differentiate, and evaluate the
+bicycle-rider's governing equations we choose to formulate and solve an optimal
+control problem via direct collocation. The bicycle-rider optimal control
+problem would test SymPy's limits.
 
-We worked on numerous areas in SymPy and downstream packages to reach the goal
-of solving a bicycle-rider biomechanical optimal control problem.
+To do this, we worked on numerous areas in SymPy and downstream packages to
+reach this goal. The work herein was primarily done by Timo Steinstra, Jan
+Heinen, Sam Brockie, and Jason Moore.
+
+.. _SymPy: https://www.sympy.org
+
+.. [BasuMandal2007] TODO
+.. [Meijaard2007] TODO
 
 General Improvements to SymPy Mechanics
 =======================================
+
+Joints Package
+--------------
+
+Timo Steinstra began with the project through a 2022 Google Summer of Code
+internship where he improved the SymPy Mechanics Joints package with
+documentation improvements, by reworking the fundamental definition of a joint,
+and adding cylindrical, planar, and spherical joints. These were key early
+updates to enable the joints package's use in constructing a bicycle-rider
+model. See the details of Timo's work in his `GSoC Report`_. This project lead
+Timo to do a TU Delft Biomechanical Design MSc project on bicycle-rider
+modeling using SymPy. Sam was the primary supervisor of Timo.
+
+.. _GSoC Report: https://github.com/sympy/sympy/wiki/GSoC-2022-Report-Timo-Stienstra-:-Enhancing-the-Joints-Framework
+
+TODO: Maybe add a figure showing one of Timo's nice joints figures from the
+SymPy docs.
 
 Symbolic Solutions to Linear Equations
 --------------------------------------
@@ -42,15 +74,15 @@ Kane's Method relies on solving three sets of linear equations:
 
 1. putting the kinematical differential equations in explicit form
 2. putting the dynamical differential equations in explicit form
-3. solving the dependent generalized speeds in terms of the indepdent
-  generalised speeds
+3. solving the dependent generalized speeds in terms of the independent
+   generalised speeds
 
 If these equations are symbolic, it is impossible to determine a zero-pivot in
-Gaussian elimination and the solutions can easily aquire divide-by-zero
-operattions for ranges of numerical values for the variables involved.
+Gaussian elimination and the solutions can easily acquire divide-by-zero
+operations for ranges of numerical values for the variables involved.
 
 There are two ways to deal with this 1) only do these solves numerically and 2)
-ensure there are no zero-divisions with careful choice of algorthm or variable
+ensure there are no zero-divisions with careful choice of algorithm or variable
 choice. 1. is easy to manage if you set q' = u.
 
 In ?2014?, we switched to using ``LUsolve()`` for all of these linear solves,

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -315,6 +315,20 @@ pathways are located in the new pathway_ module.
 These new objects provide core building blocks for developing musculotendon
 actuators and managing a full multibody system.
 
+System Class
+------------
+
+Timo developed a new `System()`_ class that manages all the information about a
+multibody system (coordinates, joints, bodies, constraints, etc.) and can
+generate the equations of motion from the high level description of the system
+without having to manually write the mathematical equations. This approach
+generally reduces the amount of code needed to generate the equations for
+complex systems. See the `Four-bar Linkage`_ example to get an idea of how it
+works.
+
+.. _System(): https://docs.sympy.org/dev/modules/physics/mechanics/api/system.html#sympy.physics.mechanics._system.System
+.. _Four-bar Linkage: https://docs.sympy.org/dev/modules/physics/mechanics/examples/four_bar_linkage_example.html
+
 Introducing SymPy Biomechanics
 ==============================
 

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -7,7 +7,7 @@ SymPy CZI Code Generation & Biomechanics Outcomes
        muscles, optimal control, bicycle, skateboard, code generation
 :category: research
 :slug: sympy-czi-outcomes
-:authors: Jason K. Moore, Sam Brockie
+:authors: Jason K. Moore
 :summary: Summary of the work performed under the Chan-Zuckerberg Foundation
           Open Source Software for Science Cycle 4 grant awarded to Sympy, and
           performed by Delft University of Technology. We developed new

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -144,6 +144,8 @@ The inertia object lets you associate a dyadic with a point, to completely
 define an inertia. Force and Torque are named tuples that associate a vector
 and point and a vector and a frame, respectively.
 
+Pathways
+
 An Actuator describes the equal and opposite pair of forces or torques.
 
 System
@@ -152,29 +154,116 @@ System
 Introduction of SymPy Biomechanics
 ==================================
 
+We've developed a new sub-package sympy.physics.biomechanics_ that enables
+including musculotendon force actuators in multibody dynamics models created
+with ``sympy.physics.mechanics``. ``biomechanics`` contains these primary
+modules:
+
+- ``curve.py``: contains classes that represent mathmathical functional
+  relationships between muscle-tendon length, velocity, and force.
+- ``activation.py``: TODO
+- ``musculotendon.py``: contains classes that represent complete musculatendon
+  models with one example implementation
+
+We have also developed two tutorials to introduce how to construct and use the
+new acutators:
+
+- `Introduction to Biomechanical Modeling
+  <https://docs.sympy.org/dev/tutorials/biomechanics/biomechanics.html>`_
+- `Biomechanical Model Example
+  <https://docs.sympy.org/dev/tutorials/biomechanics/biomechanical-model-example.html>`_
+
+.. figure:: https://docs.sympy.org/dev/_images/biomechanics-steerer.svg
+
+   Muscle driven arm pushing and pulling a lever taken from the new tutorial.
+
+.. _sympy.physics.biomechanics: https://docs.sympy.org/dev/modules/physics/biomechanics/index.html
+
 SymPy Code Generation
 =====================
 
-lambdify should handle large expressions
+lambdify should handle large expressions (didn't handle bike model before,
+point to pydy PR)
 
 - code gen
   - lambdify docstring speed up
   - MatrixSolve
+  - cse jacobian
 - dagify
 
+Demonstration
+=============
+
+As explained in the introduction, our goal is to make SymPy capbale of deriving
+very efficient neuromusular multibody models. A use case for these models is
+solving `optimal control`_ problems, which benefit greatly from the fastest
+numerical evaluation of the equations of motion and its higher order partial
+derivatives. In particluar, forming a `nonlinear programming`_ problem using
+direct collocation transcription from very large symbolic equations of motion
+was already known to push SymPy's past its limits. In the past, we have
+developed two software packages that transcribe and solve optimal control
+problems based on SymPy expressions: opty_ and pycollo_.
+
+.. _optimal control: https://en.wikipedia.org/wiki/Optimal_control
+.. _nonlinear programming: https://en.wikipedia.org/wiki/Nonlinear_programming
+.. _opty: https://github.com/csu-hmc/opty
+.. _pycollo: https://github.com/brocksam/pycollo
+
+Optimal Skateboard Ollie
+-------------------------
+
+As a first demonstration that SymPy can be used to help solve complex optimal
+control problems, TU Delft MSc student Jan Heinen began working on developing a
+model of a skateboarder performing an ollie, the fundamental jumping trick in
+the sport. Jan used SymPy to formulate the equations of motion of this
+biomechanical human-machine system and used pycollo to solve the multi-phase
+trajectory optimization and parameter identification optimal control problem.
+Jan succeeded and produced an MSc thesis and a preprint that is currently udner
+review at Sports Engineering:
+
+- `Optimal Skateboard Geometry for Maximizing Ollie Height
+  <http://resolver.tudelft.nl/uuid:61f4e969-8bd1-4687-9942-b70024b216dc>`_"
+- `Maximizing Ollie Height by Optimizing Control Strategy and Skateboard
+  Geometry Using Direct Collocation <https://doi.org/10.31224/3171>`_
+
+This video shows the simulations of the problem solutions:
+
+.. raw:: html
+
+   <center>
+   <iframe width="560" height="315"
+   src="https://www.youtube.com/embed/jw5DmNnvD7c" title="YouTube video player"
+   frameborder="0" allow="accelerometer; autoplay; clipboard-write;
+   encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+   </center>
+
+Following his MSc project, Jan contributed Sphinx documentation to the pycollo
+project with the following pull requests:
+
+- https://github.com/brocksam/pycollo/pull/80
+- https://github.com/brocksam/pycollo/pull/82
+- https://github.com/brocksam/pycollo/pull/84
+- https://github.com/brocksam/pycollo/pull/85
+- https://github.com/brocksam/pycollo/pull/87
+- https://github.com/brocksam/pycollo/pull/88
+
 BRiM
-====
+----
 
 - BMD paper & Timo's thesis
 
-Optimal Skateboard Ollie
-========================
-
-- Jan's work: thesis & paper
-- pycollo documentation
+  doi.org/10.59490/6504c5a765e8118fc7b106c3
 
 Optimal Bicycle-Rider Trajectories
-==================================
+----------------------------------
+
+The premise of the motivating hard-to-solve example is given a multibody model
+of the Carvallo-Whipple bicycle model
+
+Given a desired path on the ground, follow the path as closely as possible
+while minimizing the activation of the arm muscles.
+
+https://github.com/csu-hmc/opty/pull/102
 
 - opty improvements
 - muscle driven bicycle model

--- a/content/czi-sympy-wrapup.rst
+++ b/content/czi-sympy-wrapup.rst
@@ -14,12 +14,14 @@ SymPy CZI Code Generation & Biomechanics Outcomes
    :width: 60%
    :align: center
 
-   * - |czi-logo|
-     - |sympy-logo|
+   * - |sympy-logo|
+     - |czi-logo|
 
 .. |sympy-logo| image:: https://objects-us-east-1.dream.io/mechmotum/sympy-logo.png
+   :height: 160px
 
 .. |czi-logo| image:: https://objects-us-east-1.dream.io/mechmotum/czi-logo.png
+   :height: 200px
 
 .. contents::
    :local:
@@ -29,7 +31,7 @@ Introduction
 ============
 
 We were awarded a `two year grant`_ from CZI to improve SymPy_. There were
-three themes associated with each of the three co-principal investigators:
+three work packages led by each of the three co-principal investigators:
 
 - Improve SymPy's Documentation (Aaron Meuer, Quantsight)
 - Improve SymPy's Performance (Oscar Benjamin, University of Bristol)
@@ -38,32 +40,33 @@ three themes associated with each of the three co-principal investigators:
 
 .. _two year grant: https://doi.org/10.6084/m9.figshare.16590053.v1
 
-We were in charge of the last one and hired Dr. Sam Brockie to work on the
-project as a postdoctoral researcher. Jan Heinen and Timo Stienstra worked on
-the project through their TU Delft MSc projects under the supervision of Sam
+We were in charge of the last work package and hired Dr. Sam Brockie to work on
+the project as a postdoctoral researcher. Jan Heinen and Timo Stienstra worked
+on the project through their TU Delft MSc projects under the supervision of Sam
 and Jason.
 
 Our overarching goal is to use SymPy to generate symbolic dynamical models of
 biomechanical systems, i.e. multibody systems actuated by muscles. This
 involves formulating the Newton-Euler equations of motion, possibly with
 additional kinematical constraints, and the differential equations that
-describe the relationship between neurological activation and generated muscles
+describe the relationship between neurological excitation and generated muscles
 forces.
 
-We selected a complex human-machine system as a benchmark problem: the bicycle
-and its rider. The nonlinear and linear equations of motion of a riderless
-bicycle are traditionally a very challenging system to derive correctly in full
-symbolic form ( [BasuMandal2007]_, [Meijaard2007]_). Including a model of a
-human rider with muscle activation increases its complexity even further. This
-model is made up of hundreds of thousands of arithmetic and transcendental
-operations, making it a challenging system to differentiate and evaluate
-efficiently. We want SymPy to be able to handle models of this and more
-complexity with ease.  To test SymPy's ability to correctly derive,
-differentiate, and evaluate the bicycle-rider's governing equations we choose
-to formulate and solve an optimal control problem via direct collocation. We
-beleived that the bicycle-rider optimal control problem would test SymPy's
-limits, forcing us to make significant improvements to SymPy. To do this, we
-worked on numerous areas in SymPy and downstream packages to reach this goal.
+We selected a complex human-machine system as a benchmark problem to motivate
+our work: the bicycle and its rider. The nonlinear and linear equations of
+motion of a riderless bicycle have traditionally been a very challenging system
+to derive correctly in full symbolic form (see [BasuMandal2007]_ and
+[Meijaard2007]_ for background). Including a model of a human rider with muscle
+driven joints increases the model's complexity even further. This model is made
+up of millions of arithmetic and transcendental operations, making it a
+challenging system to differentiate and evaluate efficiently. We want SymPy to
+be able to handle models of this complexity with ease. To test SymPy's ability
+to correctly derive, differentiate, and evaluate the bicycle-rider's governing
+equations, we choose to formulate and solve an optimal control problem via
+direct collocation. We knew that the bicycle-rider optimal control problem
+would test SymPy's limits, forcing us to make significant improvements to
+SymPy's code generation features. To do this, we worked on numerous areas in
+SymPy and downstream packages to reach this goal.
 
 .. _SymPy: https://www.sympy.org
 
@@ -73,21 +76,19 @@ General Improvements to SymPy Mechanics
 Joints Package
 --------------
 
-Timo Steinstra began with the project through a 2022 Google Summer of Code
-internship where he improved the SymPy Mechanics Joints package with
+Timo Stienstra began working on this project through a 2022 Google Summer of
+Code internship where he improved the SymPy Mechanics Joints package with
 documentation improvements, by reworking the fundamental definition of a joint,
-and adding cylindrical, planar, and spherical joints. These were key early
+and adding new cylindrical, planar, and spherical joints. These were key early
 updates to enable the joints package's use in constructing a bicycle-rider
 model. See the details of Timo's work in his `GSoC Report`_. This project lead
 Timo to do a TU Delft Biomechanical Design MSc project on bicycle-rider
-modeling using SymPy. Sam was the primary supervisor of Timo.
+modeling using SymPy.
 
 .. _GSoC Report: https://github.com/sympy/sympy/wiki/GSoC-2022-Report-Timo-Stienstra-:-Enhancing-the-Joints-Framework
 
-TODO: Maybe add a figure showing one of Timo's nice joints figures from the
-SymPy docs. SVG scaling with "width" seems to crop not scale.
-
-.. list-table::
+.. list-table:: Figure 1: Old and new joint types with new explanatory figures
+   can be found in the SymPy documentation.
    :class: borderless
    :align: center
    :width: 100%
@@ -100,23 +101,23 @@ SymPy docs. SVG scaling with "width" seems to crop not scale.
    * - |joint5|
      - |joint6|
 
-.. |joint1| image:: https://docs.sympy.org/dev/_images/PinJoint.svg
-   :height: 200px
+.. |joint1| image:: https://objects-us-east-1.dream.io/mechmotum/PinJoint.png
+   :height: 180px
 
-.. |joint2| image:: https://docs.sympy.org/dev/_images/PrismaticJoint.svg
-   :height: 200px
+.. |joint2| image:: https://objects-us-east-1.dream.io/mechmotum/PrismaticJoint.png
+   :height: 180px
 
-.. |joint3| image:: https://docs.sympy.org/dev/_images/CylindricalJoint.svg
-   :height: 200px
+.. |joint3| image:: https://objects-us-east-1.dream.io/mechmotum/CylindricalJoint.png
+   :height: 180px
 
-.. |joint4| image:: https://docs.sympy.org/dev/_images/PlanarJoint.svg
-   :height: 200px
+.. |joint4| image:: https://objects-us-east-1.dream.io/mechmotum/PlanarJoint.png
+   :height: 180px
 
-.. |joint5| image:: https://docs.sympy.org/dev/_images/SphericalJoint.svg
-   :height: 200px
+.. |joint5| image:: https://objects-us-east-1.dream.io/mechmotum/SphericalJoint.png
+   :height: 180px
 
-.. |joint6| image:: https://docs.sympy.org/dev/_images/WeldJoint.svg
-   :height: 200px
+.. |joint6| image:: https://objects-us-east-1.dream.io/mechmotum/WeldJoint.png
+   :height: 180px
 
 Symbolic Solutions to Linear Equations
 --------------------------------------
@@ -124,189 +125,333 @@ Symbolic Solutions to Linear Equations
 Kane's Method relies on solving three sets of linear equations:
 
 1. putting the kinematical differential equations in explicit form
-   :math:`\dot{\mathbf{q}} = \mathbf{M}_k^{-1}\mathbf{u}`
+   :math:`\dot{\mathbf{q}} = \mathbf{M}_k^{-1}\left(\mathbf{u} +
+   \mathbf{f}_k\right)`
 2. putting the dynamical differential equations in explicit form
-   :math:`\dot{\mathbf{u}} = \mathbf{M}_d^{-1}\mathbf{f}(\mathbf{u}, \mathbf{q}, t)`
+   :math:`\dot{\mathbf{u}} = \mathbf{M}_d^{-1}\mathbf{f}_d`
 3. solving the dependent generalized speeds in terms of the independent
    generalised speeds
-   :math:`\mathbf{u}_s = \mathbf{A}^{-1}\mathbf{u}_r`
+   :math:`\mathbf{u}_r = \mathbf{A}_r^{-1}(\mathbf{A}_s\mathbf{u}_s + \mathbf{f}_{rs})`
 
-If these equations are symbolic, it is impossible to determine a zero-pivot in
-Gaussian elimination and the solutions are suseptible to divide-by-zero
-operations for ranges of numerical values for the variables involved.
+If these equations are symbolic, it is mostly impossible to determine if an
+entry is zero when pivoting in `Gaussian elimination`_ and the solutions are
+susceptible to divide-by-zero operations for ranges of numerical values for the
+variables involved.
 
-There are three ways to deal with this:
+.. _Gaussian elimination: https://en.wikipedia.org/wiki/Gaussian_elimination
+
+There are four ways, it seems, to deal with this:
 
 1. select the generalized coordinates, generalized speeds, and constants such
    that divide-by-zero cannot occur for the numerical values of interest
-2. select Gaussian elimination algorithm that does not put the solutions in a
-   form that have divide-by-zero for the numerical values of interest
-3. use a zero-division free Gaussian elimination algorithm
-4. do the Gaussian elimination numerically for any specific set of numerical
-   values
+2. select symbolic Gaussian elimination algorithms that do not put the
+   solutions in a form that have divide-by-zero for the numerical values of
+   interest
+3. use a zero-division free linear solve algorithm
+4. defer the linear solves to numerical algorithms
 
-Alternative Symbolic Solvers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. choosing generalized coordinates and speeds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO : Link to the paper that Luke cites.
+
+2. Alternative Symbolic Solvers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In 2014, we switched to using ``LUsolve()`` for all of the linear solves in
-Mechanics in `PR 7581`_, which resulted in divide-by-zero issues for complex
-problems. That change broke a test that solved the linear Carvallo-Whipple
-bicycle model to a machine precision match against published benchmarks as well
-as the corresponding `documentation page
-<https://docs.sympy.org/latest/modules/physics/mechanics/examples/bicycle_example.html>`_.
-This bug has hounded us for 9 years (see https://github.com/pydy/pydy/pull/122,
+SymPy Mechanics in `PR 7581`_, which resulted in a unnoticed regression of
+divide-by-zero issues for complex problems. That change broke the crucial
+`test_kane3.py`_ as well as the corresponding `documentation page
+<https://docs.sympy.org/latest/modules/physics/mechanics/examples/bicycle_example.html>`_
+that solved the linear Carvallo-Whipple bicycle model to a machine precision
+match against published benchmarks. This bug has hounded us for 9 years (see
+https://github.com/pydy/pydy/pull/122 and
 https://github.com/sympy/sympy/issues/9641).
 
 .. _PR 7581: https://github.com/sympy/sympy/pull/7581
+.. _test_kane3.py: https://github.com/sympy/sympy/blob/master/sympy/physics/mechanics/tests/test_kane3.py
 
 Timo discovered the fundamental divide-by-zero issue after `much sleuthing and
 discussion`_. He then introduced a new linear solver that uses `Cramer's
 rule`_, which can eliminate divide-by-zero operations in many cases. We then
-added support to ``KanesMethod`` and ``Linearizer`` for using linear solvers
-other than ``LUSolve()`` including the new Cramer's rule-based solver. With
-this we closed the `9 year old bug`_ and allowed out base bicycle model to
-build both in non-linear and linear forms.
-
-- Cramer Solve: https://github.com/sympy/sympy/pull/25179
+added support to ``KanesMethod()`` and ``Linearizer()`` for using linear
+solvers other than ``LUSolve()`` including the new Cramer's rule-based solver
+as an option. With this we closed the `9 year old bug`_ and allowed our base
+bicycle model to build both in non-linear and linear forms. The new Cramer
+solve method for matrices was introduced in
+https://github.com/sympy/sympy/pull/25179.
 
 .. _much sleuthing and discussion: https://github.com/sympy/sympy/issues/24780
 .. _Cramer's rule: https://en.wikipedia.org/wiki/Cramer%27s_rule
 .. _new linear solver: https://github.com/sympy/sympy/pull/25179
 .. _9 year old bug: https://github.com/sympy/sympy/issues/9641
 
-Delayed Numerical Solves
-~~~~~~~~~~~~~~~~~~~~~~~~
+3. division free linear solves
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO : Add reference to the division free alg
+
+4. Delayed Numerical Solves
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It would be helpful if we could delay linear solves to the numerical
+evaluation, so that pivot points can managed by LAPACK_'s solvers. To do so, we
+would need to be able to use the results of a linear solve like any other
+symbol without symbolically evaluating the linear solve operation. The
+following SymPy code almost works as desired:
+
+.. _LAPACK: https://www.netlib.org/lapack/
 
 .. code-block:: python
+
+   from sympy import MatrixSymbol, Inverse, lambdify
 
    A = MatrixSymbol('A', 2, 2)
    b = MatrixSymbol('b', 2, 1)
    x = Inverse(A) @ b
    result = x[0, 0] + x[1, 0]
-   eval_x = lambdify((A, b), result)
+   eval_result = lambdify((A, b), result)
 
-The above works but the linear solve is handled symbolically::
+The above works but the inverse and matrix multiplication are evaluated
+symbolically when called, as can be seen in the generated function:
 
-   Signature: f(A, b)
-   Docstring:
-   Created with lambdify. Signature:
+.. code-block:: pycon
 
-   func(A, b)
-
-   Expression:
-
-   A[0, 0]*b[1, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) - A[0, 1]*b[1, 0]/(A[0,...
-
+   >>> help(eval_result)
+   ...
    Source code:
 
    def _lambdifygenerated(A, b):
        return A[0, 0]*b[1, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) - A[0, 1]*b[1, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) - A[1, 0]*b[0, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0]) + A[1, 1]*b[0, 0]/(A[0, 0]*A[1, 1] - A[0, 1]*A[1, 0])
+   ...
 
-
-   Imported modules:
-
-We'd like lambdify to generate code that looks like:
+Instead, we'd like ``lambdify()`` to generate code that looks more like:
 
 .. code-block:: python
 
-   def eval_x(A, b):
+   def eval_result(A, b):
       x = numpy.linalg.solve(A, b)
       return x[0, 0] + x[1, 0]
 
-which allows NumPy (or actually lapack) to use the best algorithm given the
-numerical values used for A and b. The expression `Inverse(A) @ b` would need
-to remain unevaluated for that to work.
+which allows NumPy (or actually LAPACK) to use the appropriate algorithm given
+the numerical values used for A and b. The expression ``Inverse(A) @ b`` would
+need to remain unevaluated for code generation to properly handle it. In SymPy,
+there is a ``MatrixSolve()`` code generation node that acts as an unevaluated
+linear equation solver and works as desired with ``lambdify()``:
+
+.. code-block:: pycon
+
+   >>> from sympy.codegen.matrix_nodes import MatrixSolve
+   >>> x = MatrixSolve(A, b)
+   >>> eval_x = lambdify((A, b), x)
+   >>> help(eval_x)
+   ...
+   Source code:
+
+   def _lambdifygenerated(A, b):
+       return solve(A, b)
+   ...
+
+But ``MatrixSolve()`` does not support indexing the solution:
+
+.. code-block:: pycon
+
+   >>> result = x[0, 0] + x[1, 0]
+   ---------------------------------------------------------------------------
+   NotImplementedError                       Traceback (most recent call last)
+   Cell In[8], line 1
+   ----> 1 result = x[0, 0] + x[1, 0]
+
+   File ~/miniconda/lib/python3.9/site-packages/sympy/matrices/expressions/matexpr.py:300, in MatrixExpr.__getitem__(self, key)
+       298 i, j = _sympify(i), _sympify(j)
+       299 if self.valid_index(i, j) != False:
+   --> 300     return self._entry(i, j)
+       301 else:
+       302     raise IndexError("Invalid indices (%s, %s)" % (i, j))
+
+   File ~/miniconda/lib/python3.9/site-packages/sympy/matrices/expressions/matexpr.py:243, in MatrixExpr._entry(self, i, j, **kwargs)
+       242 def _entry(self, i, j, **kwargs):
+   --> 243     raise NotImplementedError(
+       244         "Indexing not implemented for %s" % self.__class__.__name__)
+
+   NotImplementedError: Indexing not implemented for MatrixSolve
+
+Timo has an open pull request that uses ``BlockMatrix()`` with
+``MatrixSolve()`` for the solution of dependent speeds in ``KanesMethod``, that
+can at least give this delayed solve with ``lambdify(modules='NumPy')``, see
+https://github.com/sympy/sympy/pull/24916.
 
 Inertia, Loads, Actuators
 -------------------------
 
-We introduced three helper classes:
-
-- ``Inertia()``
-- ``Force``, ``Torque``
+We introduced three new helper classes to extend the functionality of inertia
+and loads beyond that of simply dyadics and vectors: ``Inertia()``,
+``Force()``, and ``Torque()``.
 
 The inertia object lets you associate a dyadic with a point, to completely
-define an inertia. Force and Torque are named tuples that associate a vector
-and point and a vector and a frame, respectively.
+define inertia for a rigid body, particle, or collection of them. Force and
+Torque are named tuples that associate a vector and point and a vector and a
+frame, respectively.
 
-Pathways
+We have introduced an actuator_ module that has classes that describes the
+equal and opposite pair of forces or torques and force actuators can operate
+along a pathway, generating resultant forces on points that lie along the
+pathway. We included a linear spring and damper as example actuators. The
+pathways are located in the new pathway_ module.
 
-An Actuator describes the equal and opposite pair of forces or torques.
+.. _actuator: https://docs.sympy.org/dev/modules/physics/mechanics/api/actuator.html
+.. _pathway: https://docs.sympy.org/dev/modules/physics/mechanics/api/pathway.html
 
-System
-------
+These new objects provide core building blocks for developing musculotendon
+actuators and managing a full multibody system.
 
-SymPy Biomechanics
-==================
+Introducing SymPy Biomechanics
+==============================
 
-We've developed a new sub-package sympy.physics.biomechanics_ that enables
+We have developed a new sub-package, sympy.physics.biomechanics_, that enables
 including musculotendon force actuators in multibody dynamics models created
 with ``sympy.physics.mechanics``. ``biomechanics`` contains these primary
 modules:
 
-- ``curve.py``: contains classes that represent mathmathical functional
-  relationships between muscle-tendon length, velocity, and force.
-- ``activation.py``: TODO
-- ``musculotendon.py``: contains classes that represent complete musculatendon
-  models with one example implementation
+- ``curve.py``: contains classes that represent mathematical functional
+  relationships between the time varying muscle-tendon length, velocity, and
+  force
+- ``activation.py``: contains classes that manage the excitation to activation
+  dynamics
+- ``musculotendon.py``: contains classes that represent complete musculotendon
+  models with one reference implementation
 
 A full explanation of this package and the modules can be found in the new
 `Introduction to Biomechanical Modeling
 <https://docs.sympy.org/dev/tutorials/biomechanics/biomechanics.html>`_
-tutorial. We demonstrate the package on a non-trivial system in the new
-`Biomechanical Model Example
+tutorial. We demonstrate the package on a non-trivial biomechanical system in
+the new `Biomechanical Model Example
 <https://docs.sympy.org/dev/tutorials/biomechanics/biomechanical-model-example.html>`_
 tutorial.
 
 .. figure:: https://docs.sympy.org/dev/_images/biomechanics-steerer.svg
    :align: center
-   :width: 80%
+   :width: 60%
 
-   Muscle driven arm pushing and pulling a lever taken from the new tutorial.
+   Muscle (red) driven arm (black C and D) pushing and pulling a lever taken
+   from the new tutorial.
 
 .. _sympy.physics.biomechanics: https://docs.sympy.org/dev/modules/physics/biomechanics/index.html
 
-Code Generation
-===============
+Code Generation Improvements
+============================
 
-``lambdify()`` is the primary interface for converting SymPy expressions into
-NumPy-backed Python functions for numerical evaluation. ``lamdify()`` has not
-been able to code generate large mechanics' models in the past. We proposed
-adding common subexpression elmination support to help with that. ``cse()``
-support was added to ``lambdify()`` before we started the CZI work in
-https://github.com/sympy/sympy/pull/21546. ``lambdify()`` was still quite slow
-for our benchmark problems and Sam sped up lambdify's code generation by
-disabling the docstring generation for large expressions in
-https://github.com/sympy/sympy/pull/24754.
+The function `lambdify()`_ is the primary interface for converting SymPy
+expressions into NumPy-powered Python functions for numerical evaluation.
+``lambdify()`` relies on SymPy's code generation to generate the appropriate
+Python code. ``lambdify()`` has not been able to handle large mechanics models
+in the past. We proposed adding common subexpression elimination (CSE) support
+to help with that.  Support for the `cse()`_ function was added to
+``lambdify()`` just before we started the CZI work in
+https://github.com/sympy/sympy/pull/21546. Here is an example that demonstrates
+some of the speed improvements:
 
-It is commonly needed to evaluate both a function and its Jacobian. SymPy is
-capable of taking the analytical derivatives but it can be prohibitly slow for
-large expressions. If common subexpressions are extracted from a SymPy
-expression, all operations are represented as a directed acyclic graph. Taking
-the derivative of a directed acyclic graph instead of a tree graph, as SymPy
-stores expressions, can provide exponential speedups to differentiation. If the
-code generation for the function and its Jacobian uses common subexpression
-elinimation, then it makes sense to call ``cse()`` on the function, then take
-the partial derivatives, and the Jacobian will be in a DAG form for easy code
-generation. Sam has introduced a major code generation speed up for
-lambdifying large SymPy expressions if you desire the Jacobian.
+.. code-block:: python
 
-- forward_jacobian: https://github.com/sympy/sympy/pull/25801
-- https://github.com/sympy/sympy/pull/24649
-- https://github.com/sympy/sympy/pull/25797
+   from sympy import count_ops, lambdify
+   from sympy.physics.mechanics import find_dynamicsymbols, dynamicsymbols
+   from sympy.physics.mechanics.models import n_link_pendulum_on_cart
+   import numpy as np
 
-Demonstration
-=============
+Generating the equations of motion with ``KanesMethod`` will be faster for some
+models in the next release of SymPy due to `Pull Request 24792
+<https://github.com/sympy/sympy/pull/24792>`_. This shows the speed in SymPy
+1.11.1:
 
-As explained in the introduction, our goal is to make SymPy capbale of deriving
-very efficient neuromusular multibody models. A use case for these models is
-solving `optimal control`_ problems, which benefit greatly from the fastest
-numerical evaluation of the equations of motion and its higher order partial
-derivatives. In particluar, forming a `nonlinear programming`_ problem using
-direct collocation transcription from very large symbolic equations of motion
-was already known to push SymPy's past its limits. In the past, we have
-developed two software packages that transcribe and solve optimal control
-problems based on SymPy expressions: opty_ and pycollo_.
+.. code-block:: ipython
+
+   In [1]: %time kane = n_link_pendulum_on_cart(n=14)
+   CPU times: user 7.45 s, sys: 3.69 ms, total: 7.46 s
+   Wall time: 7.47 s
+
+and the same in the tip of the master branch (1.13.dev0):
+
+.. code-block:: ipython
+
+   In [1]: %time kane = n_link_pendulum_on_cart(n=14)
+   CPU times: user 4.85 s, sys: 3.81 ms, total: 4.85 s
+   Wall time: 4.85 s
+
+.. code-block:: python
+
+   large_expr = kane.mass_matrix_full @ kane.forcing_full
+   x = list(find_dynamicsymbols(large_expr))
+   p = list(large_expr.free_symbols)
+   p.remove(dynamicsymbols._t)
+   x_vals, p_vals  = np.random.random(len(x)), np.random.random(len(p))
+
+These expressions have almost 300 thousand operations:
+
+.. code-block:: ipython
+
+   In [1]: count_ops(large_expr)
+   Out[1]: 282836
+
+In SymPy 1.12, lambdifying large expressions will take at least half the time
+as prior versions because there is wasted time printing the full expression to
+the docstring. Sam sped up lambdify's code generation by disabling the
+docstring generation for large expressions in `Pull Request 24754
+<https://github.com/sympy/sympy/pull/24754>`_. Note that lambdifying
+expressions is also faster with ``cse=True``. Here is the timing in SymPy
+1.11.1:
+
+.. code-block:: ipython
+
+   In [1]: %time f_without_cse = lambdify((x, p), large_expr)
+   CPU times: user 29.4 s, sys: 91.3 ms, total: 29.5 s
+   Wall time: 29.5 s
+
+   In [2]: %time f_with_cse = lambdify((x, p), large_expr, cse=True)
+   CPU times: user 14.5 s, sys: 15.8 ms, total: 14.5 s
+   Wall time: 14.5 s
+
+and then the same in SymPy 1.12:
+
+.. code-block:: ipython
+
+   In [1]: %time f_without_cse = lambdify((x, p), large_expr)
+   CPU times: user 17.9 s, sys: 68.4 ms, total: 18 s
+   Wall time: 18 s
+
+   In [2]: %time f_with_cse = lambdify((x, p), large_expr, cse=True)
+   CPU times: user 2.77 s, sys: 7.93 ms, total: 2.77 s
+   Wall time: 2.77 s
+
+Using ``cse=True`` with ``lambdify()``, results in significantly faster
+numerical evaluation:
+
+.. code-block:: ipython
+
+   In [2]: %timeit f_without_cse(x_vals, p_vals)
+   40.7 ms ± 824 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+   In [3]: %timeit f_with_cse(x_vals, p_vals)
+   264 µs ± 7.37 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
+
+For this example, the CSE version is **154X faster** at execution.
+
+.. _lambdify(): https://docs.sympy.org/latest/modules/utilities/lambdify.html#sympy.utilities.lambdify.lambdify
+.. _cse(): https://docs.sympy.org/latest/modules/simplify/simplify.html#sympy.simplify.cse_main.cse
+
+Modeling and Optimal Control Uses
+=================================
+
+As explained in the introduction, our goal is to make SymPy capable of deriving
+computationally efficient neuromuscular driven multibody models. One use case
+for these models is solving `optimal control`_ problems, which benefit greatly
+from the fastest numerical evaluation of the equations of motion and its higher
+order partial derivatives. In particular, forming a `nonlinear programming`_
+problem using direct collocation transcription from very large symbolic
+equations of motion was already known to push SymPy's past its limits. In the
+past, we have developed two software packages that transcribe and solve optimal
+control problems based on SymPy expressions: opty_ and pycollo_. We use both
+programs below to solve two challenging optimal control problems and detail the
+improvements we made to the packages.
 
 .. _optimal control: https://en.wikipedia.org/wiki/Optimal_control
 .. _nonlinear programming: https://en.wikipedia.org/wiki/Nonlinear_programming
@@ -316,14 +461,14 @@ problems based on SymPy expressions: opty_ and pycollo_.
 Optimal Skateboard Ollie
 -------------------------
 
-As a first demonstration that SymPy can be used to solve research grade complex
-optimal control problems, TU Delft MSc student Jan Heinen began working on
-developing a model of a skateboarder performing an ollie, the fundamental
-jumping trick in the sport. Jan used SymPy to formulate the equations of motion
-of this biomechanical human-machine system and used pycollo to solve the
-multi-phase trajectory optimization and parameter identification optimal
-control problem.  Jan succeeded and produced an MSc thesis and a preprint that
-is currently udner review at Sports Engineering:
+As a first demonstration that SymPy can be used to solve research-grade optimal
+control problems, TU Delft MSc student Jan Heinen developed a model of a
+skateboarder performing an ollie, the fundamental jumping trick in the sport.
+Jan used SymPy to formulate the equations of motion of this biomechanical
+human-machine system and used pycollo to solve the multi-phase trajectory
+optimization and parameter identification optimal control problem. Jan
+succeeded and produced an MSc thesis and a preprint that is currently under
+review at the journal Sports Engineering:
 
 - TU Delft MSc thesis: `Optimal Skateboard Geometry for Maximizing Ollie Height
   <http://resolver.tudelft.nl/uuid:61f4e969-8bd1-4687-9942-b70024b216dc>`_
@@ -342,8 +487,8 @@ This video shows the simulations of the problem solutions:
    encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
    </center>
 
-Following his MSc project, Jan contributed Sphinx documentation to the pycollo
-project with the following pull requests:
+Following his MSc project, Jan contributed Sphinx documentation and examples to
+the pycollo project with the following pull requests:
 
 - https://github.com/brocksam/pycollo/pull/80
 - https://github.com/brocksam/pycollo/pull/82
@@ -357,85 +502,167 @@ BRiM
 
 All of our prior bicycle-rider human-machine system models were one-off
 derivations that were repurposed for each new model variation. These had
-varying accessiblity for easy use by other users. Timo came up with the idea to
-develop a software package that allows you to build bicycle-rider models from
-modular elements, yet still retain a minimial coorindate derivation of the
-equations of motion. His MSc thesis, "`BRiM: A Modular Bicycle-Rider Modeling
-Framework
+varying accessibility for other users. Timo came up with the idea to develop a
+software package that allows you to build bicycle-rider models from modular
+elements, yet still retain a minimal coordinate derivation of the equations of
+motion. His MSc thesis, "`BRiM: A Modular Bicycle-Rider Modeling Framework
 <http://resolver.tudelft.nl/uuid:a2b132e9-8d38-4553-8587-0c9e3341b202>`__",
 details the design, implementation, and use of BRiM. We also wrote a paper,
 "`BRiM: A Modular Bicycle-Rider Modeling Framework
 <https://doi.org/10.59490/6504c5a765e8118fc7b106c3>`__", for the Bicycle and
 Motorcycle Dynamics 2023 conference that gives a more concise overview of the
-package as well as demonstrating easily swapping models for optimal control
-results.
+package as well as demonstrating easily swapping models for comparable optimal
+control results.
 
-.. figure:: https://tjstienstra.github.io/brim/_images/lane_change.gif
+.. figure:: https://objects-us-east-1.dream.io/mechmotum/brim-lane-change.gif
    :align: center
    :width: 80%
 
-   Lane change simulation created with BRiM showing without and without a rider
+   Lane change simulation created with BRiM showing without and without a
+   rider.
 
 - BRiM source code: https://github.com/TJStienstra/brim/
 - BRiM documentation: https://tjstienstra.github.io/brim/
+- BRiM BMD 2023 paper: https://doi.org/10.59490/6504c5a765e8118fc7b106c3
+- BRiM BMD 2023 paper source code: https://github.com/TJStienstra/brim-bmd-2023-paper
 
 Optimal Bicycle-Rider Trajectories
 ----------------------------------
 
-With all of the above work, we were able to solve a muscle-driven optimal
-control problem of the bicycle and rider. This is the problem we posed:
+With all of the above work, we were able to solve a optimal control problem of
+the muscle-driven bicycle and rider. This is the problem we posed:
 
    Given a multibody model of the Carvallo-Whipple bicycle model extended with
-   a rider that has muscle acutated movable arms and given a desired path on
-   the ground, can we find muscle activations that cause the bicycle-rder to
+   a rider that has muscle actuated movable arms and given a desired path on
+   the ground, can we find muscle activations that cause the bicycle-rider to
    follow the path as closely as possible while minimizing the effort from the
-   the representative bicep and tricep muscles?
+   representative biceps and triceps?
 
 The objective of this optimal control problem takes the form:
 
 .. math::
 
-   J = (1 - w)\int_{t_0}^{t_f} (x_s(t) - x_d(t))^2 dt + w\int_{t_0}^{t_f} e(t)^2 dt
+   J = (1 - w)\int_{t_0}^{t_f} \left[x_s(t) - x_d(t)\right]^2 dt +
+   w\int_{t_0}^{t_f} e(t)^2 dt
 
 where :math:`x_s` are a subset of the model's state trajectories and
 :math:`x_d` are some desired trajectories and :math:`e` are the muscle
-excittions.
+excitation inputs. :math`w` is a weighting factor for the two terms. This is a
+typical minimal effort tracking formulation.
 
-Forming the constraints that represent the equations of motion (set of
-differential algebraic equations) involves computing a very large sparse
-Jacobian. When we first attempted this differentiation of the discretized
-bicycle-rider model, SymPy bogged down on the Jacobian calculation. We let the
-computation run for **over 3 hours** and killed the execution before the
-Jacobian completed. SymPy's differentation is untenable for large equations of
-motion.  Since we already cse the functions before code generation in opty, Sam
-implemented a forward Jacobian on the cse'd expressions in:
-
-https://github.com/csu-hmc/opty/pull/102
+The equations of motion of this system have about 2.3 million mathematical
+operations. Forming the constraints that represent these equations of motion (a
+set of differential algebraic equations in this case) involves computing a very
+large sparse Jacobian. When we first attempted the differentiation for the
+Jacobian of the discretized bicycle-rider model, SymPy bogged down on the
+Jacobian calculation. We let the computation run for **over 3 hours** and
+killed the execution before the computation completed. SymPy's differentiation
+is unusable for large equations of motion, such as these. Since we already find
+the common sub-expressions of the equations of motion before code generation in
+opty, Sam implemented a very efficient forward Jacobian on the expression DAG
+in pull request: https://github.com/csu-hmc/opty/pull/102.
 
 This allowed the equations to be differentiated and the differentiation occurs
-in less that a few minutes, showing the drastic improvements such an approach
-can have. With that improvement, we were able to solve the muscle driven
-bicycle-rider path tracking problem with opty. Once this fix was applied we
-could solve the trajectory optimization problem with opty_.
+in less than 30 seconds (**>360X** speed increase), showing the drastic
+improvements such an approach can have. Once this fix was applied we were
+finally able to solve the tracking trajectory optimization problem with opty_.
 
-Other
-=====
+TODO : figure of simulation results
 
-pytest pr
+The simulation codes and the draft paper about the results can be found in the
+following repository:
 
-Lessons Learned
-===============
+https://github.com/brocksam/muscle-driven-bicycle-paper
 
-- 6 months to negotiate a contract
-- 6 months to hire someone
+The need to evaluate both a function and its Jacobian is a common use case.
+SymPy is capable of taking the analytical derivatives but it can be prohibitory
+slow for large expressions. If common subexpressions are extracted from a SymPy
+expression, all operations are represented as a directed acyclic graph. Taking
+the derivative of a directed acyclic graph instead of a tree graph, as SymPy
+stores expressions, can provide exponential speedups to differentiation. If the
+code generation for the function and its Jacobian uses common subexpression
+elimination, then it makes sense to call ``cse()`` on the function, then take
+the partial derivatives, and the Jacobian will be in a DAG form for easy code
+generation. Sam has introduced a major code generation speed up for lambdifying
+large SymPy expressions if you desire the Jacobian.
+
+- forward_jacobian: https://github.com/sympy/sympy/pull/25801
+- https://github.com/sympy/sympy/pull/24649
+- https://github.com/sympy/sympy/pull/25797
 
 Conclusion
 ==========
 
 We completed almost all of the goals set out in the original proposal along
-with as many more unplanned outcomes. Primarliy we have improved SymPy such
-that it can be used to solve non-trivial biomechanical optimal control
-problems.
+with many more unplanned achievements. SymPy is now more suited for solving
+non-trivial biomechanical optimal control problems and improvements to the
+performance of lambdify() will help a broad set of use cases.
+
+Lessons Learned
+---------------
+
+New contributors to large open source projects should start with pull requests
+that are small and uncontroversial to build up momentum. Sam started with a
+pull request to switch SymPy's 15 year old testing framework to pytest. This
+consumed a lot of time and stalled regularly which in return stalled his other
+pull requests because he built out the tests with advanced pytest features.
+
+We had planned for 0.5 FTE over the two year period, but it took about 6 months
+to negotiate a subcontract between TU Delft and Quantsight, since it was the
+first one of its kind. After that, it took another six months before Sam could
+start. There was not enough time in the grant period for the contract and
+hiring process. It still worked out, but this is something to plan for in the
+future.
+
+We developed a large plan for the additions to SymPy that was tough to separate
+into independent smaller pieces. This led Sam and Timo to work on a set of
+large interconnected Git branches that would be merged when finished. This
+ended up leaving us with very large pull requests to review and made it harder
+for other SymPy developers to interact on the draft work. We also merged all of
+the new material as private modules (leading underscores in their file names)
+so that we could make breaking changes in case a SymPy release occurred before
+we finished the whole plan. The development branch approach was not ideal,
+SymPy usually has only one development branch, so we should probably avoid that
+in the future. Merging private modules is a fine approach and is done in other
+places in SymPy, but you have to have a plan to make them public.
+
+Our proposal had three work packages. After hiring Sam, we realized his prior
+experience and ideas for SymPy improvement had overlap with Oscar's plans. By
+the time we understood what exactly we would do, we failed to have more
+collaborative work between the two related work packages. In the future, it would be
+good to have more early brainstorm meetings to initiate close collaboration.
+
+Work Summary
+============
+
+The following list summarizes the various products we have (so far) delivered
+as part of the CZI funding (code, papers, documentation):
+
+- Pull requests to SymPy:
+
+  - https://github.com/sympy/sympy/pulls?q=is%3Apr+label%3A%22CZI%3A+Codegen%2FBiomech%22
+  - https://github.com/sympy/sympy_benchmarks/pulls?q=is%3Apr+author%3Abrocksam
+
+- Pull request to opty: https://github.com/csu-hmc/opty/pull/102
+- Pull requests to pycollo:
+
+  - https://github.com/brocksam/pycollo/pull/80
+  - https://github.com/brocksam/pycollo/pull/82
+  - https://github.com/brocksam/pycollo/pull/84
+  - https://github.com/brocksam/pycollo/pull/85
+  - https://github.com/brocksam/pycollo/pull/87
+  - https://github.com/brocksam/pycollo/pull/88
+
+- BRiM software package:
+
+  - Source code: https://github.com/TJStienstra/brim/
+  - Documentation: https://tjstienstra.github.io/brim/
+  - BMD 2023 paper: https://doi.org/10.59490/6504c5a765e8118fc7b106c3
+  - BMD 2023 paper source code: https://github.com/TJStienstra/brim-bmd-2023-paper
+
+- Bicycle steering optimal control paper:
+
+  - https://github.com/brocksam/muscle-driven-bicycle-paper
 
 References
 ==========
@@ -449,3 +676,7 @@ References
    "Hands-free circular motions of a benchmark bicycle," Proceedings of the
    Royal Society A: Mathematical, Physical and Engineering Sciences, vol. 463,
    no. 2084, pp. 1983–2003, Aug. 2007.
+.. [DeGroote2016] De Groote, F., Kinney, A. L., Rao, A. V., & Fregly, B. J.,
+   Evaluation of direct collocation optimal control problem formulations for
+   solving the muscle redundancy problem, Annals of biomedical engineering,
+   44(10), (2016) pp. 2922-2936


### PR DESCRIPTION
@brocksam I've starting drafting up a wrap up blog post. Will work on it over the next month as we finalize things.

Outline and writing tasks:

- [x] Quick recap of what the grant was about and what our specific goals were.
- [x] Improvements to SymPy Mechanics
  - [x] Joints (maybe just mention/link to Timo's GSoC report)
  - [x] Zero divisions and numerical stability of the linear solves in `KanesMethod` and `LInearizer`, bicycle model fixed
  - [x] `Force`, `Torque`, `Inertia`, and `Actuator` classes
  - [x] `System`
- [x] Improvements to code gen
  - [x] lambdify speed up (doesn't print full docstring), can now evaluate the bike model with numpy (couldn't before)
  - [x] Support for passing CSEd expressions: https://github.com/sympy/sympy/pull/24649 and https://github.com/sympy/sympy/pull/25797
  - [x] Faster Jacobians in CSEd form for codegen: https://github.com/sympy/sympy/pull/25801
- [x] Introduction to SymPy Biomechanics
- [x] BRiM
- [x] Optimal Control
  - [x] PyCollo documentation and bug fixes
  - [x] Opty cse differentiation
- [x] Solving the skateboard optimal control problem
- [x] Solving muscle driven bicycle steerer
- [x] Future ideas